### PR TITLE
Scrap RTD badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Generated files
+.repo-summary-key
+repo-summary.html


### PR DESCRIPTION
Scrap RTD badge. Also update gitignore file. Fix #15.

Theoretically, we can also expand that same function to scrap Appveyor badge (xref #12), given that the badge URL is tied to Appveyor ownership rather than GitHub org.