### PR TITLE
RTD badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# Generated files
+.repostats-key
+repository_summary.html

--- a/repostats/repostats.py
+++ b/repostats/repostats.py
@@ -342,7 +342,8 @@ def make_summary_page(repo_data=None, columns=None, outpage=None):
         if repo['license'] is None:
             license = "None Found"
         else:
-            license = repo['license']['spdx_id']
+            # Was: repo['license']['spdx_id']
+            license = repo['license']['name'].replace('"', "'")
 
         try:
             astroconda_contrib = repo['astroconda-rel']
@@ -1132,7 +1133,7 @@ if __name__ == "__main__":
     stats = get_statistics(org=org, name=name)
     print_text_summary(stats)
 
-    repos = [name, 'synphot_refactor', 'asdf']
+    repos = [name, 'synphot_refactor', 'asdf', 'stginga']
     repo_data = get_repo_info(
         org=org, repos=repos, pub_only=True, astroconda=True)
     make_summary_page(repo_data)

--- a/repostats/repostats.py
+++ b/repostats/repostats.py
@@ -37,6 +37,7 @@ _pulse_week = "https://github.com/{0:s}/{1:s}/pulse/weekly"
 
 __repo_stats_key = '.repostats-key'
 
+
 def get_auth():
     """get authentication information from user read-only file.
 
@@ -676,6 +677,7 @@ def print_text_summary(stats=None):
             print("No open pull requests")
     else:
         print("No stats available")
+
 
 def read_response_file(filename=None):
     """Read a JSON response file.

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,10 @@ show-response = 1
 minversion = 2.2
 norecursedirs = build docs/_build relic
 
+[flake8]
+ignore = E126,E128,E501
+exclude = setup.py
+
 [entry_points]
 
 [bdist_wheel]


### PR DESCRIPTION
* Scrap RTD badge. Fix #15.
* Address a little of #13.
* Also update gitignore file.

Theoretically, we can also expand that same function to scrap Appveyor badge (xref #12), given that the badge URL is tied to Appveyor ownership rather than GitHub org.